### PR TITLE
Fix appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,5 +9,3 @@ build_script:
 - ps: .\buildscripts\build.ps1
 test_script:
 - ps: .\buildscripts\test.ps1
-after_test:
-- ps: .\buildscripts\publish.ps1

--- a/buildscripts/install.ps1
+++ b/buildscripts/install.ps1
@@ -10,7 +10,7 @@ $null = Import-PackageProvider @provParams
 $requiredModules = @('Pester','PowerShellGet','PSScriptAnalyzer')
 foreach ($m in $requiredModules) {
 	Write-Host "Installing module [$($m)]..."
-	Install-Module -Name $m -Force -Confirm:$false
+	Install-Module -Name $m -Force -Confirm:$false -SkipPublisherCheck
 	Remove-Module -Name $m -Force -ErrorAction Ignore
 	Import-Module -Name $m
 }

--- a/buildscripts/install.ps1
+++ b/buildscripts/install.ps1
@@ -5,9 +5,12 @@ $provParams = @{
 }
 
 $null = Install-PackageProvider @provParams
+$null = Install-Module -Name PowerShellGet -Force -Confirm:$false -SkipPublisherCheck
+$provParams.Name = 'PowerShellGet'
+$provParams.MinimumVersion = '1.6.0'
 $null = Import-PackageProvider @provParams
 
-$requiredModules = @('Pester','PowerShellGet','PSScriptAnalyzer')
+$requiredModules = @('Pester','PSScriptAnalyzer')
 foreach ($m in $requiredModules) {
 	Write-Host "Installing module [$($m)]..."
 	Install-Module -Name $m -Force -Confirm:$false -SkipPublisherCheck


### PR DESCRIPTION
Appveyor is failing to build because NuGet doesn't like the install of PSScriptAnalyzer. 

Also lots of things don't like to update because Microsoft certificate, so added the -SkipPublisherCheck in there.