### PR TITLE
Update Version Support table to list PSv6

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@ This is what PSSoftware is all about. Removing the complexities of software mana
 
 ## Version Support
 
-| PSv1 | PSv2 | PSv3 | PSv4 | PSv5     |
-|------|------|------|------|----------|
-| No   | No  | Yes  | Yes  | Untested |
+| PSv1 | PSv2 | PSv3 | PSv4 | PSv5     | PSv6  |
+|------|------|------|------|----------|-------|
+| No   | No   | Yes  | Yes  | Untested | No    |
 
 ## Getting Started
 


### PR DESCRIPTION
Setting it to No as PSv6 doesn't support WmiObject cmdlets.

(I am working on a branch that converts these to CimCmdlet's that should be ready in a week or two)