### PR TITLE
Fixes #14

### DIFF
--- a/PSSoftware.psm1
+++ b/PSSoftware.psm1
@@ -759,7 +759,7 @@ function Stop-MyProcess
 					{
 						foreach ($p in $WmiProcess)
 						{
-							if ($PSCmdlet.ShouldProcess("Process ID: $($p.Id)", 'Stop'))
+							if ($PSCmdlet.ShouldProcess("Process ID: $($p.ProcessId)", 'Stop'))
 							{
 								$WmiResult = $p.Terminate()
 								if ($WmiResult.ReturnValue -eq 1603)


### PR DESCRIPTION
Fixes the error in #14.

Does *not* fix that CimInstance doesn't have Terminate() method, and therefore cannot be used in PowerShell 6.